### PR TITLE
Add GitHub Actions CI (RuboCop + RSpec)

### DIFF
--- a/.default_rubocop.yml
+++ b/.default_rubocop.yml
@@ -7,6 +7,7 @@ AllCops:
   NewCops: disable
   Exclude:
     - "node_modules/**/*"
+    - "vendor/**/*"
 
 #################### Bundler ###############################
 
@@ -732,7 +733,7 @@ Naming/MethodName:
 Naming/MethodParameterName:
   Enabled: true
 
-Naming/PredicateName:
+Naming/PredicatePrefix:
   Enabled: false
 
 Naming/RescuedExceptionsVariableName:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,36 @@
+name: CI
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+
+jobs:
+  lint:
+    name: RuboCop
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "3.4"
+          bundler-cache: true
+      - run: bundle exec rubocop
+
+  test:
+    name: RSpec (Ruby ${{ matrix.ruby }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby: ["3.3", "3.4", "4.0"]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+          bundler-cache: true
+      # Chrome is preinstalled on ubuntu-latest runners; Selenium Manager
+      # (bundled with selenium-webdriver) resolves the matching chromedriver
+      # for the headless_chrome driver used by the feature specs.
+      - run: bundle exec rspec

--- a/rosette.gemspec
+++ b/rosette.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
   spec.executables << "rosette"
 
-  spec.required_ruby_version = ">= 3.2.0"
+  spec.required_ruby_version = ">= 3.3.0"
 
   spec.add_dependency "i18n-tasks", "~> 1.1"
   spec.add_dependency "rails", "~> 8.0"


### PR DESCRIPTION
Adds a GitHub Actions workflow: RuboCop + RSpec on Ruby 3.3 / 3.4 / 4.0.

- Exclude `vendor/` from RuboCop (vendored gems ship configs with `inherit_gem: rubocop-discourse`)
- Rename obsolete `Naming/PredicateName` → `Naming/PredicatePrefix`
- Raise `required_ruby_version` to `>= 3.3.0` (parallel, via rubocop, needs 3.3+)